### PR TITLE
Fix: Convert variable-length lookbehinds to PCRE-compatible form

### DIFF
--- a/autogenerated/shell.tmLanguage.json
+++ b/autogenerated/shell.tmLanguage.json
@@ -1203,7 +1203,7 @@
     "interpolation": {
       "patterns": [
         {
-          "include": "#arithmetic_dollar"
+          "include": "#arithmetic_no_dollar"
         },
         {
           "include": "#subshell_dollar"
@@ -1280,7 +1280,7 @@
       "name": "comment.line.double-slash.shell",
       "patterns": [
         {
-          "include": "#line_continuation_character"
+          "include": "#line_continuation"
         }
       ]
     },
@@ -1802,7 +1802,7 @@
       ]
     },
     "normal_statement": {
-      "begin": "(?:(?!^[ \\t]*+$)(?:(?<=^until | until |\\tuntil |^while | while |\\twhile |^elif | elif |\\telif |^else | else |\\telse |^then | then |\\tthen |^do | do |\\tdo |^if | if |\\tif )|(?<=(?:^|;|\\||&|!|\\(|\\{|\\`)))(?:[ \\t]*+)(?!nocorrect\\W|nocorrect\\$|function\\W|function\\$|foreach\\W|foreach\\$|repeat\\W|repeat\\$|logout\\W|logout\\$|coproc\\W|coproc\\$|select\\W|select\\$|while\\W|while\\$|pushd\\W|pushd\\$|until\\W|until\\$|case\\W|case\\$|done\\W|done\\$|elif\\W|elif\\$|else\\W|else\\$|esac\\W|esac\\$|popd\\W|popd\\$|then\\W|then\\$|time\\W|time\\$|for\\W|for\\$|end\\W|end\\$|fi\\W|fi\\$|do\\W|do\\$|in\\W|in\\$|if\\W|if\\$))",
+      "begin": "(?:(?!^[ \\t]*+$)(?:(?<=^until | until |\\tuntil |^while | while |\\twhile |^elif | elif |\\telif |^else | else |\\telse |^then | then |\\tthen |^do | do |\\tdo |^if | if |\\tif )|(?<=^|;|\\||&|!|\\(|\\{|\\`))(?:[ \\t]*+)(?!nocorrect\\W|nocorrect\\$|function\\W|function\\$|foreach\\W|foreach\\$|repeat\\W|repeat\\$|logout\\W|logout\\$|coproc\\W|coproc\\$|select\\W|select\\$|while\\W|while\\$|pushd\\W|pushd\\$|until\\W|until\\$|case\\W|case\\$|done\\W|done\\$|elif\\W|elif\\$|else\\W|else\\$|esac\\W|esac\\$|popd\\W|popd\\$|then\\W|then\\$|time\\W|time\\$|for\\W|for\\$|end\\W|end\\$|fi\\W|fi\\$|do\\W|do\\$|in\\W|in\\$|if\\W|if\\$))",
       "end": "(?=;|\\||&|\\n|\\)|\\`|\\{|\\}|[ \\t]*#|\\])(?<!\\\\)",
       "beginCaptures": {
       },


### PR DESCRIPTION
## Summary

Fix PCRE-incompatible lookbehind and two broken include references.

## Changes

### PCRE compatibility

The `normal_statement.begin` regex wraps lookbehind alternatives in a non-capturing group, which prevents PCRE from auto-splitting:

```regex
# Before (PCRE cannot auto-split through the (?:...) wrapper)
(?<=(?:^|;|\||&|!|\(|\{|\`))

# After (PCRE auto-splits top-level alternatives)
(?<=^|;|\||&|!|\(|\{|\`)
```

### Broken includes

Two include references point to non-existent repository keys:

- `#arithmetic_dollar` -> `#arithmetic_no_dollar` (fixes arithmetic scoping in interpolation)
- `#line_continuation_character` -> `#line_continuation` (fixes backslash continuation in comments)

## Why

There is a [PR on github-linguist/linguist](https://github.com/github-linguist/linguist/pull/7794) to replace the archived `atom/language-shellscript` grammar with `better-shell-syntax` for GitHub.com syntax highlighting. These fixes are required for that integration.