### PR TITLE
Fix `<name>` and `ab>c` losing their last character to argument-vs-redirect ambiguity (#111)

### DIFF
--- a/autogenerated/shell.tmLanguage.json
+++ b/autogenerated/shell.tmLanguage.json
@@ -100,7 +100,7 @@
     "argument_context": {
       "patterns": [
         {
-          "match": "(?:[ \\t]*+)((?:[^ \t\n>&;<>\\(\\)\\$`\\\\\"'<\\|]+)(?!>))",
+          "match": "(?:[ \\t]*+)((?:(?<=[<>])[^ \t\n\\|&;<>\\(\\)\\$`\\\\\"'<>]+|[^ \t\n\\|&;<>\\(\\)\\$`\\\\\"'<>]*[^ \t\n0-9\\|&;<>\\(\\)\\$`\\\\\"'<>][^ \t\n\\|&;<>\\(\\)\\$`\\\\\"'<>]*|[^ \t\n\\|&;<>\\(\\)\\$`\\\\\"'<>]+(?!\\d*>)))",
           "captures": {
             "1": {
               "name": "string.unquoted.argument.shell",
@@ -301,7 +301,7 @@
       ]
     },
     "basic_command_name": {
-      "match": "(?:(?:(?!(?:!|&|\\||\\(|\\)|\\{|\\[|<|>|#|\\n|$|;|[ \\t]))(?!nocorrect |nocorrect\t|nocorrect$|readonly |readonly\t|readonly$|function |function\t|function$|foreach |foreach\t|foreach$|coproc |coproc\t|coproc$|logout |logout\t|logout$|export |export\t|export$|select |select\t|select$|repeat |repeat\t|repeat$|pushd |pushd\t|pushd$|until |until\t|until$|while |while\t|while$|local |local\t|local$|case |case\t|case$|done |done\t|done$|elif |elif\t|elif$|else |else\t|else$|esac |esac\t|esac$|popd |popd\t|popd$|then |then\t|then$|time |time\t|time$|for |for\t|for$|end |end\t|end$|fi |fi\t|fi$|do |do\t|do$|in |in\t|in$|if |if\t|if$))(?:((?<=^|;|&|[ \\t])(?:readonly|declare|typeset|export|local)(?=[ \\t]|;|&|$))|((?!\"|'|\\\\\\n?$)(?:[^!'\"<> \\t\\n\\r]+?)))(?:(?= |\\t)|(?:(?=;|\\||&|\\n|\\)|\\`|\\{|\\}|[ \\t]*#|\\])(?<!\\\\))))",
+      "match": "(?:(?:(?!(?:!|&|\\||\\(|\\)|\\{|\\[|<|>|#|\\n|$|;|[ \\t]))(?!nocorrect |nocorrect\t|nocorrect$|function |function\t|function$|readonly |readonly\t|readonly$|foreach |foreach\t|foreach$|coproc |coproc\t|coproc$|export |export\t|export$|logout |logout\t|logout$|repeat |repeat\t|repeat$|select |select\t|select$|local |local\t|local$|pushd |pushd\t|pushd$|until |until\t|until$|while |while\t|while$|case |case\t|case$|done |done\t|done$|elif |elif\t|elif$|else |else\t|else$|esac |esac\t|esac$|popd |popd\t|popd$|then |then\t|then$|time |time\t|time$|end |end\t|end$|for |for\t|for$|do |do\t|do$|fi |fi\t|fi$|if |if\t|if$|in |in\t|in$))(?:((?<=^|;|&|[ \\t])(?:readonly|declare|typeset|export|local)(?=[ \\t]|;|&|$))|((?!\"|'|\\\\\\n?$)(?:[^!'\"<> \\t\\n\\r]+?)))(?:(?= |\\t)|(?:(?=;|\\||&|\\n|\\)|\\`|\\{|\\}|[ \\t]*#|\\])(?<!\\\\))))",
       "captures": {
         "1": {
           "name": "storage.modifier.$1.shell"
@@ -314,7 +314,7 @@
               "name": "keyword.control.$0.shell"
             },
             {
-              "match": "(?<!\\w)(?:(?:unfunction|continue|autoload|unsetopt|bindkey|builtin|getopts|command|declare|unalias|history|unlimit|typeset|suspend|source|printf|unhash|disown|ulimit|return|which|alias|break|false|print|shift|times|umask|umask|unset|read|type|exec|eval|wait|echo|dirs|jobs|kill|hash|stat|exit|test|trap|true|let|set|pwd|cd|fg|bg|fc|:|\\.)(?!\\/))(?!\\w)(?!-)",
+              "match": "(?<!\\w)(?:(?:unfunction|autoload|continue|unsetopt|bindkey|builtin|command|declare|getopts|history|suspend|typeset|unalias|unlimit|disown|printf|return|source|ulimit|unhash|alias|break|false|print|shift|times|umask|umask|unset|which|dirs|echo|eval|exec|exit|hash|jobs|kill|read|stat|test|trap|true|type|wait|let|pwd|set|bg|cd|fc|fg|:|\\.)(?!\\/))(?!\\w)(?!-)",
               "name": "support.function.builtin.shell"
             },
             {
@@ -513,7 +513,7 @@
           "name": "entity.name.function.call.shell entity.name.command.shell keyword.control.$0.shell"
         },
         {
-          "match": "(?<!\\w)(?:(?:unfunction|continue|autoload|unsetopt|bindkey|builtin|getopts|command|declare|unalias|history|unlimit|typeset|suspend|source|printf|unhash|disown|ulimit|return|which|alias|break|false|print|shift|times|umask|umask|unset|read|type|exec|eval|wait|echo|dirs|jobs|kill|hash|stat|exit|test|trap|true|let|set|pwd|cd|fg|bg|fc|:|\\.)(?!\\/))(?!\\w)(?!-)",
+          "match": "(?<!\\w)(?:(?:unfunction|autoload|continue|unsetopt|bindkey|builtin|command|declare|getopts|history|suspend|typeset|unalias|unlimit|disown|printf|return|source|ulimit|unhash|alias|break|false|print|shift|times|umask|umask|unset|which|dirs|echo|eval|exec|exit|hash|jobs|kill|read|stat|test|trap|true|type|wait|let|pwd|set|bg|cd|fc|fg|:|\\.)(?!\\/))(?!\\w)(?!-)",
           "name": "entity.name.function.call.shell entity.name.command.shell support.function.builtin.shell"
         },
         {
@@ -563,7 +563,7 @@
       ]
     },
     "command_statement": {
-      "begin": "(?:(?:[ \\t]*+)(?:(?!(?:!|&|\\||\\(|\\)|\\{|\\[|<|>|#|\\n|$|;|[ \\t]))(?!nocorrect |nocorrect\t|nocorrect$|readonly |readonly\t|readonly$|function |function\t|function$|foreach |foreach\t|foreach$|coproc |coproc\t|coproc$|logout |logout\t|logout$|export |export\t|export$|select |select\t|select$|repeat |repeat\t|repeat$|pushd |pushd\t|pushd$|until |until\t|until$|while |while\t|while$|local |local\t|local$|case |case\t|case$|done |done\t|done$|elif |elif\t|elif$|else |else\t|else$|esac |esac\t|esac$|popd |popd\t|popd$|then |then\t|then$|time |time\t|time$|for |for\t|for$|end |end\t|end$|fi |fi\t|fi$|do |do\t|do$|in |in\t|in$|if |if\t|if$)(?!\\\\\\n?$)))",
+      "begin": "(?:(?:[ \\t]*+)(?:(?!(?:!|&|\\||\\(|\\)|\\{|\\[|<|>|#|\\n|$|;|[ \\t]))(?!nocorrect |nocorrect\t|nocorrect$|function |function\t|function$|readonly |readonly\t|readonly$|foreach |foreach\t|foreach$|coproc |coproc\t|coproc$|export |export\t|export$|logout |logout\t|logout$|repeat |repeat\t|repeat$|select |select\t|select$|local |local\t|local$|pushd |pushd\t|pushd$|until |until\t|until$|while |while\t|while$|case |case\t|case$|done |done\t|done$|elif |elif\t|elif$|else |else\t|else$|esac |esac\t|esac$|popd |popd\t|popd$|then |then\t|then$|time |time\t|time$|end |end\t|end$|for |for\t|for$|do |do\t|do$|fi |fi\t|fi$|if |if\t|if$|in |in\t|in$)(?!\\\\\\n?$)))",
       "end": "(?=;|\\||&|\\n|\\)|\\`|\\{|\\}|[ \\t]*#|\\])(?<!\\\\)",
       "beginCaptures": {
       },
@@ -1802,7 +1802,7 @@
       ]
     },
     "normal_statement": {
-      "begin": "(?:(?!^[ \\t]*+$)(?:(?<=^until | until |\\tuntil |^while | while |\\twhile |^elif | elif |\\telif |^else | else |\\telse |^then | then |\\tthen |^do | do |\\tdo |^if | if |\\tif )|(?<=(?:^|;|\\||&|!|\\(|\\{|\\`)))(?:[ \\t]*+)(?!nocorrect\\W|nocorrect\\$|function\\W|function\\$|foreach\\W|foreach\\$|repeat\\W|repeat\\$|logout\\W|logout\\$|coproc\\W|coproc\\$|select\\W|select\\$|while\\W|while\\$|pushd\\W|pushd\\$|until\\W|until\\$|case\\W|case\\$|done\\W|done\\$|elif\\W|elif\\$|else\\W|else\\$|esac\\W|esac\\$|popd\\W|popd\\$|then\\W|then\\$|time\\W|time\\$|for\\W|for\\$|end\\W|end\\$|fi\\W|fi\\$|do\\W|do\\$|in\\W|in\\$|if\\W|if\\$))",
+      "begin": "(?:(?!^[ \\t]*+$)(?:(?<=^until | until |\\tuntil |^while | while |\\twhile |^elif | elif |\\telif |^else | else |\\telse |^then | then |\\tthen |^do | do |\\tdo |^if | if |\\tif )|(?<=(?:^|;|\\||&|!|\\(|\\{|\\`)))(?:[ \\t]*+)(?!nocorrect\\W|nocorrect\\$|function\\W|function\\$|foreach\\W|foreach\\$|coproc\\W|coproc\\$|logout\\W|logout\\$|repeat\\W|repeat\\$|select\\W|select\\$|pushd\\W|pushd\\$|until\\W|until\\$|while\\W|while\\$|case\\W|case\\$|done\\W|done\\$|elif\\W|elif\\$|else\\W|else\\$|esac\\W|esac\\$|popd\\W|popd\\$|then\\W|then\\$|time\\W|time\\$|end\\W|end\\$|for\\W|for\\$|do\\W|do\\$|fi\\W|fi\\$|if\\W|if\\$|in\\W|in\\$))",
       "end": "(?=;|\\||&|\\n|\\)|\\`|\\{|\\}|[ \\t]*#|\\])(?<!\\\\)",
       "beginCaptures": {
       },
@@ -1981,7 +1981,7 @@
       ]
     },
     "redirect_fix": {
-      "match": "(?:(>>?)(?:[ \\t]*+)([^ \t\n>&;<>\\(\\)\\$`\\\\\"'<\\|]+))",
+      "match": "(?:(>>?)(?:[ \\t]*+)([^ \t\n\\|&;<>\\(\\)\\$`\\\\\"'<>]+))",
       "captures": {
         "1": {
           "name": "keyword.operator.redirect.shell"
@@ -2065,7 +2065,7 @@
       }
     },
     "simple_unquoted": {
-      "match": "[^ \\t\\n>&;<>\\(\\)\\$`\\\\\"'<\\|]",
+      "match": "[^ \\t\\n\\|&;<>\\(\\)\\$`\\\\\"'<>]",
       "name": "string.unquoted.shell"
     },
     "special_expansion": {
@@ -2073,7 +2073,7 @@
       "name": "keyword.operator.expansion.shell"
     },
     "start_of_command": {
-      "match": "(?:(?:[ \\t]*+)(?:(?!(?:!|&|\\||\\(|\\)|\\{|\\[|<|>|#|\\n|$|;|[ \\t]))(?!nocorrect |nocorrect\t|nocorrect$|readonly |readonly\t|readonly$|function |function\t|function$|foreach |foreach\t|foreach$|coproc |coproc\t|coproc$|logout |logout\t|logout$|export |export\t|export$|select |select\t|select$|repeat |repeat\t|repeat$|pushd |pushd\t|pushd$|until |until\t|until$|while |while\t|while$|local |local\t|local$|case |case\t|case$|done |done\t|done$|elif |elif\t|elif$|else |else\t|else$|esac |esac\t|esac$|popd |popd\t|popd$|then |then\t|then$|time |time\t|time$|for |for\t|for$|end |end\t|end$|fi |fi\t|fi$|do |do\t|do$|in |in\t|in$|if |if\t|if$)(?!\\\\\\n?$)))"
+      "match": "(?:(?:[ \\t]*+)(?:(?!(?:!|&|\\||\\(|\\)|\\{|\\[|<|>|#|\\n|$|;|[ \\t]))(?!nocorrect |nocorrect\t|nocorrect$|function |function\t|function$|readonly |readonly\t|readonly$|foreach |foreach\t|foreach$|coproc |coproc\t|coproc$|export |export\t|export$|logout |logout\t|logout$|repeat |repeat\t|repeat$|select |select\t|select$|local |local\t|local$|pushd |pushd\t|pushd$|until |until\t|until$|while |while\t|while$|case |case\t|case$|done |done\t|done$|elif |elif\t|elif$|else |else\t|else$|esac |esac\t|esac$|popd |popd\t|popd$|then |then\t|then$|time |time\t|time$|end |end\t|end$|for |for\t|for$|do |do\t|do$|fi |fi\t|fi$|if |if\t|if$|in |in\t|in$)(?!\\\\\\n?$)))"
     },
     "string": {
       "patterns": [

--- a/language_examples/#111.sh
+++ b/language_examples/#111.sh
@@ -1,0 +1,32 @@
+# issue #111: unquoted argument before `>` lost its last character
+
+# placeholders with `<...>` -- last char must stay in string.unquoted.argument
+mkdir <name>
+git clone <url>
+cd <repo name>
+git cherry-pick -x <squash-merge-sha>
+git checkout <target-branch>
+
+# digit-suffix placeholders -- whole word stays in the argument, `>` is its own token
+echo <sha256>
+echo <h264>
+echo <8080>
+
+# `word>file` -- the word must not be split before `>`
+echo ab>c
+echo word>file
+
+# unchanged-behavior controls: fd redirects still fall through to the redirect rule
+echo hello 2>&1
+echo foo 1>out 2>err
+exec 3>&-
+exec 255>file
+echo foo 10>out
+
+# numeric argument with no redirect: unchanged
+echo 42
+
+# heredoc: unchanged
+cat <<EOF
+hi
+EOF

--- a/language_examples/#111.spec.yaml
+++ b/language_examples/#111.spec.yaml
@@ -1,0 +1,431 @@
+- source: '#'
+  scopesBegin:
+    - comment.line.number-sign
+  scopes:
+    - punctuation.definition.comment
+- source: ' issue #111: unquoted argument before `>` lost its last character'
+- source: '#'
+  scopes:
+    - punctuation.definition.comment
+- source: ' placeholders with `<...>` -- last char must stay in string.unquoted.argument'
+  scopesEnd:
+    - comment.line.number-sign
+- source: mkdir
+  scopesBegin:
+    - meta.statement
+    - meta.statement.command
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+- source: <
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - keyword.operator.redirect
+- source: name
+  scopes:
+    - string.unquoted.argument
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+  scopesEnd:
+    - meta.argument
+- source: git
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+- source: clone
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - string.unquoted.argument
+- source: <
+  scopes:
+    - keyword.operator.redirect
+- source: url
+  scopes:
+    - string.unquoted.argument
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+  scopesEnd:
+    - meta.argument
+- source: cd
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: <
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - keyword.operator.redirect
+- source: repo
+  scopesBegin:
+    - string.unquoted.argument
+- source: name
+  scopesEnd:
+    - string.unquoted.argument
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+  scopesEnd:
+    - meta.argument
+- source: git
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+- source: cherry-pick
+  scopes:
+    - meta.argument
+    - string.unquoted.argument
+- source: '-'
+  scopesBegin:
+    - string.unquoted.argument
+  scopes:
+    - constant.other.option.dash
+- source: x
+  scopes:
+    - constant.other.option
+  scopesEnd:
+    - string.unquoted.argument
+- source: <
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - keyword.operator.redirect
+- source: squash-merge-sha
+  scopes:
+    - string.unquoted.argument
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+  scopesEnd:
+    - meta.argument
+- source: git
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+- source: checkout
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - string.unquoted.argument
+- source: <
+  scopes:
+    - keyword.operator.redirect
+- source: target-branch
+  scopes:
+    - string.unquoted.argument
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+  scopesEnd:
+    - meta.statement
+    - meta.statement.command
+    - meta.argument
+- source: '#'
+  scopesBegin:
+    - comment.line.number-sign
+  scopes:
+    - punctuation.definition.comment
+- source: ' digit-suffix placeholders -- whole word stays in the argument, `>` is its own token'
+  scopesEnd:
+    - comment.line.number-sign
+- source: echo
+  scopesBegin:
+    - meta.statement
+    - meta.statement.command
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: <
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - keyword.operator.redirect
+- source: sha256
+  scopes:
+    - string.unquoted.argument
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+  scopesEnd:
+    - meta.argument
+- source: echo
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: <
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - keyword.operator.redirect
+- source: h264
+  scopes:
+    - string.unquoted.argument
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+  scopesEnd:
+    - meta.argument
+- source: echo
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: <
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - keyword.operator.redirect
+- source: '8080'
+  scopes:
+    - string.unquoted.argument
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+  scopesEnd:
+    - meta.statement
+    - meta.statement.command
+    - meta.argument
+- source: '#'
+  scopesBegin:
+    - comment.line.number-sign
+  scopes:
+    - punctuation.definition.comment
+- source: ' `word>file` -- the word must not be split before `>`'
+  scopesEnd:
+    - comment.line.number-sign
+- source: echo
+  scopesBegin:
+    - meta.statement
+    - meta.statement.command
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: ab
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - string.unquoted.argument
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+- source: c
+  scopes:
+    - string.unquoted.argument
+  scopesEnd:
+    - meta.argument
+- source: echo
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: word
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - string.unquoted.argument
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+- source: file
+  scopes:
+    - string.unquoted.argument
+  scopesEnd:
+    - meta.statement
+    - meta.statement.command
+    - meta.argument
+- source: '#'
+  scopesBegin:
+    - comment.line.number-sign
+  scopes:
+    - punctuation.definition.comment
+- source: ' unchanged-behavior controls: fd redirects still fall through to the redirect rule'
+  scopesEnd:
+    - comment.line.number-sign
+- source: echo
+  scopesBegin:
+    - meta.statement
+    - meta.statement.command
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: hello
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - string.unquoted.argument
+- source: '2'
+  scopes:
+    - keyword.operator.redirect.stderr
+- source: '>&1'
+  scopes:
+    - keyword.operator.redirect
+  scopesEnd:
+    - meta.argument
+- source: echo
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: foo
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - string.unquoted.argument
+- source: '1'
+  scopes:
+    - keyword.operator.redirect.stdout
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+- source: out
+  scopes:
+    - string.unquoted.argument
+- source: '2'
+  scopes:
+    - keyword.operator.redirect.stderr
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+- source: err
+  scopes:
+    - string.unquoted.argument
+  scopesEnd:
+    - meta.argument
+- source: exec
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: '3'
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - keyword.operator.redirect.3
+- source: '>&'
+  scopes:
+    - keyword.operator.redirect
+- source: '-'
+  scopes:
+    - string.unquoted.argument
+  scopesEnd:
+    - meta.argument
+- source: exec
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: '255'
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - keyword.operator.redirect.255
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+- source: file
+  scopes:
+    - string.unquoted.argument
+  scopesEnd:
+    - meta.argument
+- source: echo
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: foo
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - string.unquoted.argument
+- source: '10'
+  scopes:
+    - keyword.operator.redirect.10
+- source: '>'
+  scopes:
+    - keyword.operator.redirect
+- source: out
+  scopes:
+    - string.unquoted.argument
+  scopesEnd:
+    - meta.statement
+    - meta.statement.command
+    - meta.argument
+- source: '#'
+  scopesBegin:
+    - comment.line.number-sign
+  scopes:
+    - punctuation.definition.comment
+- source: ' numeric argument with no redirect: unchanged'
+  scopesEnd:
+    - comment.line.number-sign
+- source: echo
+  scopesBegin:
+    - meta.statement
+    - meta.statement.command
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+    - support.function.builtin
+- source: '42'
+  scopes:
+    - meta.argument
+    - string.unquoted.argument
+    - constant.numeric
+    - constant.numeric.integer
+  scopesEnd:
+    - meta.statement
+    - meta.statement.command
+- source: '#'
+  scopesBegin:
+    - comment.line.number-sign
+  scopes:
+    - punctuation.definition.comment
+- source: ' heredoc: unchanged'
+  scopesEnd:
+    - comment.line.number-sign
+- source: cat
+  scopesBegin:
+    - meta.statement
+    - meta.statement.command
+  scopes:
+    - meta.statement.command.name
+    - entity.name.function.call
+    - entity.name.command
+- source: '<<'
+  scopesBegin:
+    - meta.argument
+  scopes:
+    - keyword.operator.heredoc
+- source: EOF
+  scopes:
+    - punctuation.definition.string.heredoc.delimiter
+- source: hi
+  scopes:
+    - string.unquoted.heredoc.no-indent.EOF
+- source: EOF
+  scopes:
+    - punctuation.definition.string.heredoc.delimiter

--- a/main/main.rb
+++ b/main/main.rb
@@ -400,10 +400,27 @@ require_relative './tokens.rb'
         match: /[^ \t\n#{invalid_literals}]/,
         tag_as: "string.unquoted",
     )
+    # the lookahead for `>` defers an unquoted word to the redirect rule when it
+    # is an fd prefix (ex: 1>&2). Naively `[^…]+(?!>)` backtracks one char on
+    # `ab>`, leaving the trailing letter unscoped (and `<name>` losing its `e`).
+    # Only defer when the word is all-digits at word-start; in a redirect-target
+    # position (after `<` or `>`) or whenever the word has any non-digit,
+    # consume greedily. See issue #111.
+    literal_char_class           = "[^ \t\n#{invalid_literals}]"
+    non_digit_literal_char_class = "[^ \t\n0-9#{invalid_literals}]"
+    valid_argument_match = Regexp.new(
+        "(?:" +
+            "(?<=[<>])#{literal_char_class}+" +
+            "|" +
+            "#{literal_char_class}*#{non_digit_literal_char_class}#{literal_char_class}*" +
+            "|" +
+            "#{literal_char_class}+(?!\\d*>)" +
+        ")"
+    )
     generateUnquotedArugment = ->(tag_as) do
         std_space.then(
             tag_as: tag_as,
-            match: Pattern.new(valid_literal_characters).lookAheadToAvoid(/>/), # ex: 1>&2
+            match: valid_argument_match, # ex: 1>&2 still defers to redirect rule
             includes: [
                 # wildcard
                 Pattern.new(


### PR DESCRIPTION
## Summary
Fixes issue #111 where unquoted arguments containing placeholders like `<name>` or `<url>` were losing their last character when followed by redirect operators (`>` or `<`).

## Problem
The previous regex pattern `[^…]+(?!>)` used a negative lookahead to defer fd redirects (like `1>&2`) to the redirect rule. However, this pattern would backtrack one character on inputs like `ab>c` or `<name>`, leaving the trailing character unscoped and causing syntax highlighting issues.

## Solution
Replaced the simple negative lookahead with a more sophisticated pattern that handles three cases:

1. **After redirect operators**: `(?<=[<>])[^ \t\n…]+` - Greedily consume all characters after `<` or `>` (for redirect targets)
2. **Mixed alphanumeric**: `[^ \t\n…]*[^ \t\n0-9…][^ \t\n…]*` - Consume any word containing non-digits (can't be an fd prefix)
3. **All-digit words**: `[^ \t\n…]+(?!\d*>)` - Only defer to redirect rule when the word is all-digits followed by `>`

This ensures that:
- `<name>` keeps the `e` in the argument scope
- `ab>c` doesn't split before `>`
- `word>file` stays together as an argument
- `1>&2` still correctly defers to the redirect rule
- Existing redirect behavior (like `2>&1`, `1>out`, `3>&-`) remains unchanged

## Changes
- Updated `main.rb` with new `valid_argument_match` regex pattern
- Regenerated `shell.tmLanguage.json` with the updated pattern
- Added comprehensive test cases in `#111.sh` and `#111.spec.yaml` covering all scenarios